### PR TITLE
Publish state of fnc's DdsIoFreqLink checkbox

### DIFF
--- a/stabilizer_ui/target/fnc/topics.py
+++ b/stabilizer_ui/target/fnc/topics.py
@@ -61,6 +61,9 @@ class Ui:
                 [f"iir{iir}" for iir in range(NUM_IIR_FILTERS_PER_CHANNEL)])
             for ch in range(NUM_CHANNELS)
         ]
+        self.dds_io_link_checkboxes = [
+            ui_channels[ch].create_child("dds_in_checkbox") for ch in range(NUM_CHANNELS)
+        ]
 
         for ch in range(NUM_CHANNELS):
             for iir in range(NUM_IIR_FILTERS_PER_CHANNEL):

--- a/stabilizer_ui/target/fnc/ui.py
+++ b/stabilizer_ui/target/fnc/ui.py
@@ -163,11 +163,14 @@ class UiWindow(AbstractUiWindow):
             settings_map[
                 stabilizer.frequency_dds_ins[ch].get_path_from_root()] = UiMqttConfig(
                     [self.channels[ch].ddsInFrequencyBox], *self.mega)
+            
+            settings_map[
+                ui.dds_io_link_checkboxes[ch].get_path_from_root()] = UiMqttConfig(
+                    [self.channels[ch].ddsIoFreqLinkCheckBox])
 
             # IIR settings
             for iir in range(NUM_IIR_FILTERS_PER_CHANNEL):
                 iirWidget = self.channels[ch].iir_settings[iir]
-                # iir_root = stabilizer.iirs[ch][iir]
 
                 for child in ui.iirs[ch][iir].get_children(
                     ["y_offset", "y_min", "y_max", "x_offset"]):


### PR DESCRIPTION
Previously, the checkbox defaulted to being checked on startup, leading to errors if it had been unchecked and the DDS_in frequency changed the last time it was run