### PR TITLE
Add a dictionary of stabilizer configs for simpler CLI use 

### DIFF
--- a/stabilizer_ui/device_db.py
+++ b/stabilizer_ui/device_db.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""
+A database of stabilizer devices in the group.
+Identifies the device parameters by a logical name to avoid having to manually pass them
+for every run
+
+Accepted format:
+
+<logical_name>: {
+    "mac-address": str              # The MAC address of the device
+    "application": str,             # The application the device is running; in ["fnc", "dual_iir", "l674"]
+    "broker": NetworkAddress,       # The IP address and connection port of the MQTT broker
+    "net_id": str, optional         # The MQTT topic of the stabilizer, if different from the MAC address.
+}
+
+Apart from these base parameters, each application may define additional parameters linked to a setup as needed.
+"""
+
+from .mqtt import NetworkAddress
+
+broker_255_6_4 = NetworkAddress.from_str_ip("10.255.6.4", 1883)
+wand_lab1 = NetworkAddress.from_str_ip("10.255.6.61", 3251)
+
+stabilizer_devices = {}
+stabilizer_devices["lab1_729"] = {
+    "mac-address": "80-34-28-5f-4f-5d",
+    "application": "fnc",
+    "broker": broker_255_6_4,
+}
+
+stabilizer_devices["lab1_674"] = {
+    "mac-address": "80-1f-12-5d-47-df",
+    "application": "l674",
+    "broker": broker_255_6_4,
+    "wand-address": wand_lab1,
+    "wand-channel": "lab1_674",
+    "solstis-host": "10.179.22.23",
+}

--- a/stabilizer_ui/target/fnc/app.py
+++ b/stabilizer_ui/target/fnc/app.py
@@ -15,6 +15,7 @@ from . import topics
 from ...stream.thread import StreamThread
 from ...mqtt import NetworkAddress
 from ...utils import fmt_mac, AsyncQueueThreadsafe
+from ...device_db import stabilizer_devices
 
 logger = logging.getLogger(__name__)
 
@@ -23,43 +24,48 @@ def main():
     logging.basicConfig(level=logging.INFO)
 
     parser = argparse.ArgumentParser(description="Interface for the Dual-IIR Stabilizer.")
-    parser.add_argument("-b", "--broker-host", default="10.255.6.4")
-    parser.add_argument("--broker-port", default=1883, type=int)
-    parser.add_argument("--stabilizer-mac",
-                        default="80-34-28-5f-4f-5d",
-                        help="MAC address of the stabilizer")
+    parser.add_argument("stabilizer_name", metavar="stabilizer", type=str,
+                        help="Stabilizer name as entered in the device database")
     parser.add_argument("--stream-port", default=0, type=int)
-    parser.add_argument("--name", default="FNC", help="Application name")
     parser.add_argument("--debug", action="store_true", help="Enable debug logging")
     args = parser.parse_args()
 
     if args.debug:
         logger.setLevel(logging.DEBUG)
 
+    try:
+        stabilizer = stabilizer_devices[args.stabilizer_name]
+    except KeyError:
+        logger.error(f"Device '{args.stabilizer_name}' not found in device database.")
+        sys.exit(1)
+
+    if stabilizer["application"] != "fnc":
+        logger.error(f"Device '{args.stabilizer_name}' is not listed as running FNC.")
+        sys.exit(1)
+
+    topics.app_root.name = stabilizer.get("net_id", fmt_mac(stabilizer["mac-address"]))
+    broker_address = stabilizer["broker"]
+
+    # Find out which local IP address we are going to direct the stream to. 
+    # Assume the local IP address is the same for the broker and the stabilizer.
+    local_ip = get_local_ip(broker_address.get_ip())
+    requested_stream_target = NetworkAddress(local_ip, args.stream_port)
+
     app = QtWidgets.QApplication(sys.argv)
     app.setOrganizationName("Oxford Ion Trap Quantum Computing group")
     app.setOrganizationDomain("photonic.link")
-    app.setApplicationName("FNC UI")
-
-    topics.app_root.name = f"{fmt_mac(args.stabilizer_mac)}"
+    app.setApplicationName("Stabilizer UI")
 
     with QEventLoop(app) as loop:
         asyncio.set_event_loop(loop)
 
         ui = UiWindow()
-        ui.setWindowTitle(args.name + f" [{fmt_mac(args.stabilizer_mac)}]")
+        ui.setWindowTitle(f"FNC [{args.stabilizer_name}]")
         ui.show()
 
-        ui.set_comm_status(f"Connecting to MQTT broker at {args.broker_host}…")
+        ui.set_comm_status(f"Connecting to MQTT broker at {broker_address.get_ip()}…")
 
         stabilizer_interface = StabilizerInterface()
-
-        # Find out which local IP address we are going to direct the stream to.
-        # Assume the local IP address is the same for the broker and the stabilizer.
-        local_ip = get_local_ip(args.broker_host)
-
-        requested_stream_target = NetworkAddress(local_ip, args.stream_port)
-        broker_address = NetworkAddress.from_str_ip(args.broker_host, args.broker_port)
 
         stream_target_queue = AsyncQueueThreadsafe(loop, maxsize=1)
         stream_target_queue.put_nowait(requested_stream_target)

--- a/stabilizer_ui/target/l674/lock.py
+++ b/stabilizer_ui/target/l674/lock.py
@@ -281,7 +281,7 @@ async def relock_laser(ui: UiWindow, stabilizer_interface: StabilizerInterface,
 
 
 async def monitor_lock_state(ui: UiWindow, stabilizer_interface: StabilizerInterface,
-                             wand_host: str, wand_port: int, wand_channel: str,
+                             wand_host: NetworkAddress, wand_channel: str,
                              solstis_host: str):
     # While not relocking, we regularly poll the wavemeter and save the last reading,
     # to be "graduated" to last_locked_freq_reading once we know that the laser was
@@ -291,7 +291,7 @@ async def monitor_lock_state(ui: UiWindow, stabilizer_interface: StabilizerInter
 
     # Connect to wavemeter server (but gracefully fail to allow using the UI for manual
     # operation even if the wavemeter is offline).
-    wand = WavemeterInterface(wand_host, wand_port, wand_channel, WAVEMETER_TIMEOUT)
+    wand = WavemeterInterface(wand_host.get_ip(), wand_host.port, wand_channel, WAVEMETER_TIMEOUT)
     await wand.try_connect()
     wavemeter_task = None
     if not wand.is_connected():


### PR DESCRIPTION
The dictionary defines a logical name key bundling all relevant hardware configuration information so you only need to specify which stabiliser you want to connect to by name.

Also removes default MAC addresses previously added for convenience -- the user must now explicitly state which stabiliser to connect to to prevent accidental connections. 

e.g. `$fnc_ui lab1_729`